### PR TITLE
Fixed broken commands when pcntl is disabled.

### DIFF
--- a/src/SignaledCommand.php
+++ b/src/SignaledCommand.php
@@ -28,10 +28,10 @@ abstract class SignaledCommand extends Command
 
     public static final function getDefaultStopSignals()
     {
-        return [
+        return extension_loaded('pcntl') ? [
             SIGTERM,
             SIGINT
-        ];
+        ] : [];
     }
 
     public function getStopSignals()


### PR DESCRIPTION
We've encountered the following problem with broken Symfony commands when there is no pcntl extension:

```
  An error occurred when executing the ""cache:clear --no-warmup"" command:
  Fatal error: Uncaught Symfony\Component\Debug\Exception\ContextErrorException: Notice: Use of undefined constant SIGTERM - assumed 'SIGTERM' in ...vendor\che\console-signals\src\SignaledCommand.php on line 32
```

A simple check of `extension_loaded('pcntl')` solves the problem. Otherwise one can check `defined('SIGTERM')`.